### PR TITLE
Don't try to compile the default reporter on no_std.

### DIFF
--- a/src/reporter/mod.rs
+++ b/src/reporter/mod.rs
@@ -1,1 +1,2 @@
+#[cfg(feature = "std")]
 pub mod default;


### PR DESCRIPTION
Hi Joe,
With this small change, I was able to get liar to compile and run on my STM32F3 Discovery board. I don't have a timing source configured yet, or any reporting. You can check out my code at https://github.com/smbolton/stm32f3-liar-test . Might be able to work on the timing source tomorrow. -Sean