### PR TITLE
Introduce a Runnable trait to bench non-static functions

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -4,10 +4,11 @@ use rustc_version::{version_meta, Channel};
 
 fn main() {
     let using_nightly = version_meta().unwrap().channel == Channel::Nightly;
-    let asm_capable_target =
-        cfg!(not(any(all(target_os = "nacl", target_arch = "le32"),
-                     target_arch = "asmjs",
-                     target_arch = "wasm32")));
+    let asm_capable_target = cfg!(not(any(
+        all(target_os = "nacl", target_arch = "le32"),
+        target_arch = "asmjs",
+        target_arch = "wasm32"
+    )));
     if using_nightly && asm_capable_target {
         println!("cargo:rustc-cfg=asm");
     }

--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -3,7 +3,7 @@ extern crate liar;
 
 use liar::black_box;
 use liar::bencher::Bencher;
-use liar::runner::Runner;
+use liar::runner::Runnable;
 
 
 mod acker {
@@ -19,17 +19,11 @@ mod acker {
 }
 
 // Manual benchmark definition.
-fn nop<R: Runner<S>, S>(b: &mut Bencher<R, S>) {
-    b.run(|| {});
+struct Nop;
+
+impl Runnable<()> for Nop {
+    fn body(&mut self) {}
 }
-
-// Benchmark definition with macro, allowing custom setup.
-bench!(nop_black_box, b, {
-    let m = 3;
-    let n = 2;
-
-    b.run(|| (black_box(m), black_box(n)));
-});
 
 // Succinct benchmark definition when no custom setup is needed.
 bench!(ack, {
@@ -48,7 +42,8 @@ fn main() {
     let r = fixed::FixedRunner::new(fixed::DEFAULT_ROUND_SIZE, fixed::DEFAULT_SAMPLE_SIZE);
     let mut b = Bencher::new(r);
 
-    add_bench!(b, nop);
+    add_bench!(b, Nop);
+    let nop_black_box = black_box(Nop);
     add_bench!(b, nop_black_box);
     add_bench!(b, ack);
     add_bench!(b, ack_black_box);

--- a/examples/no_std/src/main.rs
+++ b/examples/no_std/src/main.rs
@@ -22,4 +22,4 @@ extern fn eh_personality() {}
 
 #[lang = "panic_fmt"]
 #[no_mangle]  // Fixes link error: `undefined reference to `rust_begin_unwind'`
-extern fn panic_fmt() -> ! { loop {} }
+pub extern fn panic_fmt() -> ! { loop {} }

--- a/src/black_box.rs
+++ b/src/black_box.rs
@@ -12,7 +12,6 @@
 // dual-licensed, and in each case we incorporate the relevant code
 // using the MIT License option.
 
-
 /// A function that is opaque to the optimizer, to allow benchmarks to
 /// pretend to use outputs to assist in avoiding dead-code elimination.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,12 @@
 
 mod black_box;
 
-#[cfg(feature = "std")] pub mod bencher;
-#[cfg(feature = "std")] pub mod reporter;
-#[cfg(feature = "std")] pub mod runner;
+#[cfg(feature = "std")]
+pub mod bencher;
+#[cfg(feature = "std")]
+pub mod reporter;
+#[cfg(feature = "std")]
+pub mod runner;
 
 pub mod no_std;
 
@@ -20,13 +23,12 @@ pub struct Sample<T> {
 #[macro_export]
 macro_rules! bench {
     ($name:ident, $body:expr) => {
-        fn $name<R: Runner<S>, S>(b: &mut Bencher<R, S>) {
-            b.run(|| $body);
-        }
-    };
-    ($name:ident, $b:ident, $body:expr) => {
-        fn $name<R: Runner<S>, S>($b: &mut Bencher<R, S>) {
-            $body
+        #[allow(non_camel_case_types)]
+        struct $name;
+        impl Runnable<()> for $name {
+            fn body(&mut self) {
+                 $body;
+            }
         }
     };
 }
@@ -34,6 +36,6 @@ macro_rules! bench {
 #[macro_export]
 macro_rules! add_bench {
     ($b:ident, $name:ident) => {
-        $b.bench(stringify!($name), &mut $name);
+        $b.bench(stringify!($name), $name);
     }
 }

--- a/src/no_std/bencher.rs
+++ b/src/no_std/bencher.rs
@@ -1,19 +1,12 @@
 use no_std::runner::{DiffFn, Runner, Sample, TimerFn};
 
-
 pub struct Bencher<'d, T> {
     data: &'d mut [u64],
     runner: Runner<T>,
 }
 
 impl<'d, T> Bencher<'d, T> {
-    pub fn new(
-        data: &'d mut [u64],
-        timer: TimerFn<T>,
-        diff: DiffFn<T>,
-        round_size: usize,
-    ) -> Self {
-
+    pub fn new(data: &'d mut [u64], timer: TimerFn<T>, diff: DiffFn<T>, round_size: usize) -> Self {
         Bencher {
             data,
             runner: Runner::new(round_size, timer, diff),
@@ -21,8 +14,9 @@ impl<'d, T> Bencher<'d, T> {
     }
 
     pub fn run<Target, Ret>(&mut self, mut target: Target)
-        where Target: FnMut() -> Ret {
-
+    where
+        Target: FnMut() -> Ret,
+    {
         self.runner.run(&mut target, self.data);
     }
 
@@ -32,8 +26,9 @@ impl<'d, T> Bencher<'d, T> {
         target: &mut Target,
         data: &'s mut [u64],
     ) -> Sample<'s>
-        where Target: FnMut(&mut Bencher<T>) {
-
+    where
+        Target: FnMut(&mut Bencher<T>),
+    {
         target(self);
 
         for i in 0..self.data.len() {

--- a/src/no_std/runner.rs
+++ b/src/no_std/runner.rs
@@ -1,6 +1,5 @@
 use black_box::black_box;
 
-
 pub struct Sample<'d> {
     pub name: &'static str,
     pub data: &'d [u64],
@@ -17,23 +16,26 @@ pub struct Runner<T> {
 
 impl<'a, T> Runner<T> {
     pub fn new(round_size: usize, timer: TimerFn<T>, diff: DiffFn<T>) -> Self {
-        Runner { round_size, timer, diff }
+        Runner {
+            round_size,
+            timer,
+            diff,
+        }
     }
 
-    pub fn run<Target, Ret>(
-        &mut self,
-        target: &mut Target,
-        samples: &mut [u64],
-    ) where Target: FnMut() -> Ret {
-
+    pub fn run<Target, Ret>(&mut self, target: &mut Target, samples: &mut [u64])
+    where
+        Target: FnMut() -> Ret,
+    {
         for i in 0..samples.len() {
             samples[i] = self.run_round(target);
         }
     }
 
     fn run_round<Target, Ret>(&mut self, target: &mut Target) -> u64
-        where Target: FnMut() -> Ret {
-
+    where
+        Target: FnMut() -> Ret,
+    {
         let start = (self.timer)();
 
         for _ in 0..self.round_size {

--- a/src/reporter/line.rs
+++ b/src/reporter/line.rs
@@ -1,9 +1,8 @@
 use std::fmt::Debug;
 
-use ::Sample;
+use Sample;
 use reporter::Reporter;
 use runner::Round;
-
 
 pub struct LineReporter {
     delim: &'static str,

--- a/src/reporter/mod.rs
+++ b/src/reporter/mod.rs
@@ -1,7 +1,6 @@
 pub mod line;
 
-use ::Sample;
-
+use Sample;
 
 pub trait Reporter<S> {
     fn report(&self, samples: &[Sample<S>]) -> Result<(), ()>;

--- a/src/runner/fixed.rs
+++ b/src/runner/fixed.rs
@@ -1,9 +1,8 @@
 use std::time::Instant;
 
-use ::Sample;
-use runner::{Runner, to_ns};
+use Sample;
+use runner::{to_ns, Runnable, Runner};
 use black_box::black_box;
-
 
 pub const DEFAULT_ROUND_SIZE: usize = 10_000;
 pub const DEFAULT_SAMPLE_SIZE: usize = 100;
@@ -22,11 +21,12 @@ impl FixedRunner {
     }
 
     fn run_round<Target, Ret>(&mut self, round_size: usize, target: &mut Target) -> u64
-        where Target: FnMut() -> Ret {
-
+    where
+        Target: Runnable<Ret>,
+    {
         let now = Instant::now();
         for _ in 0..round_size {
-            black_box(target());
+            black_box(target.body());
         }
         let dur = now.elapsed();
 
@@ -36,11 +36,12 @@ impl FixedRunner {
 
 impl Runner<u64> for FixedRunner {
     fn run<Target, Ret>(&mut self, name: &'static str, target: &mut Target) -> Sample<u64>
-        where Target: FnMut() -> Ret {
-
+    where
+        Target: Runnable<Ret>,
+    {
         let mut data = Vec::with_capacity(self.sample_size);
 
-        let round_size = self.round_size;  // For borrowck.
+        let round_size = self.round_size; // For borrowck.
         for _ in 0..self.sample_size {
             data.push(self.run_round(round_size, target))
         }

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -3,12 +3,18 @@ pub mod linear;
 
 use std::time::Duration;
 
-use ::Sample;
+use Sample;
 
+pub trait Runnable<Ret> {
+    fn setup(&mut self) {}
+    fn teardown(&mut self) {}
+    fn body(&mut self) -> Ret;
+}
 
 pub trait Runner<S> {
     fn run<Target, Ret>(&mut self, name: &'static str, target: &mut Target) -> Sample<S>
-        where Target: FnMut() -> Ret;
+    where
+        Target: Runnable<Ret>;
 }
 
 pub struct Round {


### PR DESCRIPTION
Hi Joe,

And thanks for this awesome crate.

By design, it has a limitation that happened to be a showstopper for my use case: it can only benchmark static functions.

I would have loved to be able to use it to benchmark arbitrary functions from shared libraries.

This is one of the pull requests I would hate receiving, as it completely changes the way to use your code (and `rustfmt` also mangled things to make the diff less readable). 

Anyway, this introduces a `Runnable` trait, that can be implemented by things to be benchmarked. 
With a mandatory `run()` function and optional `setup()` and teardown()` functions.

This allows anything to be benchmarked using Liar. 

If you feel like this is a terrible idea, no worries, I can keep maintaining this as a fork.

Cheers!